### PR TITLE
Reduce height of media query to hide avatar/bio

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -147,8 +147,8 @@
   }
 }
 
-@media screen and (max-height: 800px) {
-  .account__header__avatar, .account__header__content {
+@media screen and (max-height: 480px) {
+  .account__header__avatar, .account__header .account__header__content {
     display: none;
   }
 }


### PR DESCRIPTION
An additional selector was provided to make the bio only hide on the timeline and not on the user page itself.